### PR TITLE
Added an `addPrefix` option to optionally add a prefix to property names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ validateAsync(params, [ 'price', 'quantity' ])
 });
 ```
 
-### Advanced Example
+### Advanced usage
 
-Other types of validation:
+#### Other types of validation
 
 * You can specify that at least one of a group of parameters must be included by placing those properties together within a nested array (either `username` or `email` must be specified in the example below)
 
@@ -61,6 +61,22 @@ validate(params, [
     [ 'username', 'email' ],
     { age: val => val > 30 }
 ]);
+```
+
+#### Optional parameters
+
+##### Passing in an object to which the extracted parameters will be assigned.
+
+```js
+// Sets `this.logger` and `this.username`
+validate(params, [ 'logger', 'username' ], this);
+```
+
+#### Adding a prefix to param names
+
+```js
+// Sets `this._logger` and `this._username`
+validate(params, [ 'logger', 'username' ], this, { addPrefix: '_' });
 ```
 
 ### ParameterValidator class
@@ -82,18 +98,23 @@ parameterValidator.validateAsync(options, [ 'firstName', 'lastName' ])
 ### Parameters for `validate` and `validateAsync`
 
 ```
-param:   {Object}    paramsProvided    - The names and values of provided parameters
-param:   {Array}     paramRequirements - Each item in this array is interpretted in order as a validation rule.
+param:   {Object}  paramsProvided      - The names and values of provided parameters
+param:   {Array}   paramRequirements   - Each item in this array is interpretted in order as a validation rule.
                                        - If an item is a string, it's interpretted as the name of a parameter that must be contained in paramsProvided.
                                        - If an item is an Array, it's interpretted as an array of parameter names where at least one of the
                                          parameters in the Array must be in paramsProvided.
                                        - If an item is an Object, it's assumed that the object's only key is the name of a parameter to be validated
                                          and its corresponding value is a function that returns true if that parameter's value in paramsProvided is
                                          valid.
-param:   {Object}    [extractedParams] - This method returns an object containing the names and values of the validated parameters extracted.
+param:   {Object}  [extractedParams]   - This method returns an object containing the names and values of the validated parameters extracted.
                                          By default, it creates a new object and assigns the extracted parameters to it, but if you want this
                                          method to add the extracted params to an existing object (such as the class instance that internally
                                          invokes this method), you can optionally supply that object as the extractedParams parameter.
+
+ param:  {Object}  [options]           - Object of additional options.
+ param:  {string}  [options.addPrefix] - Specifies a prefix that will be added to each param name before it's assigned to the
+                                         extractedParams object. This is useful, for example, for prefixing property names with an underscore
+                                         to indicate that they're private properties.
 
 returns: {Object}    extractedParams   - The names and values of the validated parameters extracted.
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ param:   {Object}  [extractedParams]   - This method returns an object containin
                                          method to add the extracted params to an existing object (such as the class instance that internally
                                          invokes this method), you can optionally supply that object as the extractedParams parameter.
 
- param:  {Object}  [options]           - Object of additional options.
- param:  {string}  [options.addPrefix] - Specifies a prefix that will be added to each param name before it's assigned to the
+param:   {Object}  [options]           - Object of additional options.
+param:   {string}  [options.addPrefix] - Specifies a prefix that will be added to each param name before it's assigned to the
                                          extractedParams object. This is useful, for example, for prefixing property names with an underscore
                                          to indicate that they're private properties.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ try {
 To ensure that the any errors thrown are wrapped in a Promise, use the async version:
 
 ```js
-import { validateAsync, ParameterValidationError } from 'parameterValidator';
+import { validateAsync, ParameterValidationError } from 'parameter-validator';
 
 validateAsync(params, [ 'price', 'quantity' ])
 .then(({ price, quantity }) => {

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ validate(params, [
 validate(params, [ 'logger', 'username' ], this);
 ```
 
-#### Adding a prefix to param names
+##### Adding a prefix to param names
 
 ```js
 // Sets `this._logger` and `this._username`
@@ -116,7 +116,7 @@ param:   {Object}  [extractedParams]   - This method returns an object containin
                                          extractedParams object. This is useful, for example, for prefixing property names with an underscore
                                          to indicate that they're private properties.
 
-returns: {Object}    extractedParams   - The names and values of the validated parameters extracted.
+returns: {Object}  extractedParams     - The names and values of the validated parameters extracted.
 
 throws:  {ParameterValidationError}    - Indicates that one or more parameter validation rules failed. The error message identifies the names and
                                          values of each invalid parameter.

--- a/dist/ParameterValidator.js
+++ b/dist/ParameterValidator.js
@@ -129,15 +129,20 @@ var ParameterValidator = function () {
 
             if (!paramsProvided) {
                 // If only I could use the ParameterValidator here...
-                throw new ParameterValidationError('A paramsProvided object is required.');
+                throw new ParameterValidationError('A params object is required.');
             }
 
             if (!Array.isArray(paramRequirements)) {
                 throw new Error('paramRequirements must be an array.');
             }
 
-            var errors = [],
-                prefix = options.addPrefix || ''; // Optional prefix to be added to each parameter name.
+            var prefix = options.addPrefix || ''; // Optional prefix to be added to each parameter name.
+
+            if (typeof prefix !== 'string') {
+                throw new Error('addPrefix option must be a string if provided.');
+            }
+
+            var errors = [];
 
             var _iteratorNormalCompletion = true;
             var _didIteratorError = false;

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "parameter-validator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Parameter validator makes it easy to verify that an object contains required, valid parameters.",
   "keywords": [ "parameter", "validator", "validate", "verify", "assert", "object", "param", "property", "properties", "function", "required" ],
   "main": "dist/ParameterValidator.js",
   "scripts": {
-    "lint": "jshint src",
+    "lint": "jshint src && jshint test",
     "build": "npm run lint && rm -rf dist && babel src --out-dir dist",
     "test": "mocha --compilers js:babel-core/register"
   },

--- a/src/ParameterValidator.js
+++ b/src/ParameterValidator.js
@@ -67,13 +67,20 @@ export default class ParameterValidator {
     validate(paramsProvided, paramRequirements, extractedParams = {}, options = {}) {
         if (!paramsProvided) {
         	// If only I could use the ParameterValidator here...
-            throw new ParameterValidationError(`A paramsProvided object is required.`);
+            throw new ParameterValidationError(`A params object is required.`);
         }
 
-        if (!Array.isArray(paramRequirements)) { throw new Error('paramRequirements must be an array.'); }
+        if (!Array.isArray(paramRequirements)) {
+            throw new Error('paramRequirements must be an array.');
+        }
 
-        let errors = [],
-            prefix = options.addPrefix || ''; // Optional prefix to be added to each parameter name.
+        let prefix = options.addPrefix || ''; // Optional prefix to be added to each parameter name.
+
+        if (typeof prefix !== 'string') {
+            throw new Error('addPrefix option must be a string if provided.');
+        }
+
+        let errors = [];
 
         for (let paramRequirement of paramRequirements) {
         	if (Array.isArray(paramRequirement) && paramRequirement.length) {

--- a/test/ParameterValidator_spec.js
+++ b/test/ParameterValidator_spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect, fail } from 'chai';
 import sinon from 'sinon';
 import ParameterValidator from '../src/ParameterValidator';
 import { ParameterValidationError } from '../src/ParameterValidator';
@@ -198,7 +198,7 @@ describe('ParameterValidator', () => {
             });
         });
 
-        describe('execution of a cusJerry validation function', () => {
+        describe('execution of a custom validation function', () => {
             it('should return a parameter specified if it passes validation', () => {
                 var animalNames = {
                     cat: 'Garfield',
@@ -211,7 +211,7 @@ describe('ParameterValidator', () => {
                 expect(extractedParams).to.deep.equal({cat: 'Garfield'});
             });
 
-            it('should throw a ParameterValidationError if a cusJerry validation function determines a parameter is invalid', () => {
+            it('should throw a ParameterValidationError if a custom validation function determines a parameter is invalid', () => {
                 var animalNames = {
                     cat: 'Sylvester',
                     dog: 'Jake'
@@ -305,6 +305,42 @@ describe('ParameterValidator', () => {
 
                 expect(extractedParams).to.deep.equal(expectedUpdatedExistingParams);
                 expect(existingParams).to.deep.equal(expectedUpdatedExistingParams);
+            });
+        });
+
+        describe('addPrefix option', () => {
+
+            let animalNames,
+                accumulator;
+
+            beforeEach(() => {
+
+                animalNames = {
+                    dog: 'Scooby',
+                    bear: 'Yogi',
+                    penguin: 'Tux'
+                };
+
+                accumulator = {};
+            });
+
+            it(`throws an error when a value is provided that's not a string`, () => {
+
+                try {
+                    parameterValidator.validate(animalNames, [ 'penguin', 'bear' ], accumulator, { addPrefix: 4 });
+                    fail();
+                } catch (error) {
+                    expect(error).to.be.instanceof(Error);
+                }
+            });
+
+            it('adds a given string prefix to the validated properties it extracts', () => {
+
+                parameterValidator.validate(animalNames, [ 'penguin', 'bear' ], accumulator, { addPrefix: '_' });
+                expect(accumulator).to.deep.equal({
+                    _penguin: 'Tux',
+                    _bear: 'Yogi'
+                });
             });
         });
     });


### PR DESCRIPTION
I've been wanting this for a while so that I can more easily add underscores to property names before setting them on an object instance to show that they're private.

*Please ignore the changes to the transpiled files in the dist directory.*