### PR TITLE
Add the option to provide a custom Error type to throw + allow multiple custom validation functions in a single object

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,28 +98,30 @@ parameterValidator.validateAsync(options, [ 'firstName', 'lastName' ])
 ### Parameters for `validate` and `validateAsync`
 
 ```
-param:   {Object}  paramsProvided      - The names and values of provided parameters
-param:   {Array}   paramRequirements   - Each item in this array is interpretted in order as a validation rule.
-                                       - If an item is a string, it's interpretted as the name of a parameter that must be contained in paramsProvided.
-                                       - If an item is an Array, it's interpretted as an array of parameter names where at least one of the
-                                         parameters in the Array must be in paramsProvided.
-                                       - If an item is an Object, it's assumed that the object's only key is the name of a parameter to be validated
-                                         and its corresponding value is a function that returns true if that parameter's value in paramsProvided is
-                                         valid.
-param:   {Object}  [extractedParams]   - This method returns an object containing the names and values of the validated parameters extracted.
-                                         By default, it creates a new object and assigns the extracted parameters to it, but if you want this
-                                         method to add the extracted params to an existing object (such as the class instance that internally
-                                         invokes this method), you can optionally supply that object as the extractedParams parameter.
+param:   {Object}       paramsProvided       - The names and values of provided parameters
+param:   {Array}        paramRequirements    - Each item in this array is interpretted in order as a validation rule.
+                                             - If an item is a string, it's interpretted as the name of a parameter that must be contained in paramsProvided.
+                                             - If an item is an Array, it's interpretted as an array of parameter names where at least one of the
+                                               parameters in the Array must be in paramsProvided.
+                                             - If an item is an Object, it's assumed that the object's only key is the name of a parameter to be validated
+                                               and its corresponding value is a function that returns true if that parameter's value in paramsProvided is
+                                               valid.
+param:   {Object|null}  [extractedParams]    - This method returns an object containing the names and values of the validated parameters extracted.
+                                               By default, it creates a new object and assigns the extracted parameters to it, but if you want this
+                                               method to add the extracted params to an existing object (such as the class instance that internally
+                                               invokes this method), you can optionally supply that object as the extractedParams parameter.
 
-param:   {Object}  [options]           - Object of additional options.
-param:   {string}  [options.addPrefix] - Specifies a prefix that will be added to each param name before it's assigned to the
-                                         extractedParams object. This is useful, for example, for prefixing property names with an underscore
-                                         to indicate that they're private properties.
+param:   {Object}       [options]            - Object of additional options.
+param:   {string}       [options.addPrefix]  - Specifies a prefix that will be added to each param name before it's assigned to the
+                                               extractedParams object. This is useful, for example, for prefixing property names with an underscore
+                                               to indicate that they're private properties.
+param:   {class}        [options.errorClass] - Specifies a specific `Error` subclass to throw instead of the default `ParameterValidationError
+                                               when invalid parameters are detected.
 
-returns: {Object}  extractedParams     - The names and values of the validated parameters extracted.
+returns: {Object}       extractedParams      - The names and values of the validated parameters extracted.
 
-throws:  {ParameterValidationError}    - Indicates that one or more parameter validation rules failed. The error message identifies the names and
-                                         values of each invalid parameter.
+throws:  {ParameterValidationError}          - Indicates that one or more parameter validation rules failed. The error message identifies the names and
+                                               values of each invalid parameter.
 ```
 
 

--- a/dist/ParameterValidator.js
+++ b/dist/ParameterValidator.js
@@ -162,15 +162,17 @@ var ParameterValidator = function () {
                         var validationResult = this._performLogicalOrParamValidation(paramsProvided, paramRequirement);
                         this._assignProperties(extractedParams, validationResult.params, prefix);
                         errors.push.apply(errors, _toConsumableArray(validationResult.errors));
-                    } else if ((typeof paramRequirement === 'undefined' ? 'undefined' : _typeof(paramRequirement)) === 'object' && Object.keys(paramRequirement)) {
-                        // paramRequirement is an object with one key where the key is the parameter's name
-                        // and the value is a validation function that returns true if the value is valid.
-                        var paramName = Object.keys(paramRequirement)[0],
-                            validationFunction = paramRequirement[paramName],
-                            _validationResult = this._executeValidationFunction(paramsProvided, paramName, validationFunction);
+                    } else if ((typeof paramRequirement === 'undefined' ? 'undefined' : _typeof(paramRequirement)) === 'object') {
+                        // paramRequirement is an object with one or more keys where each key is a parameter's name
+                        // and its value is a validation function that returns true if the value is valid.
+                        for (var paramName in paramRequirement) {
 
-                        this._assignProperties(extractedParams, _validationResult.params, prefix);
-                        errors.push.apply(errors, _toConsumableArray(_validationResult.errors));
+                            var validationFunction = paramRequirement[paramName],
+                                _validationResult = this._executeValidationFunction(paramsProvided, paramName, validationFunction);
+
+                            this._assignProperties(extractedParams, _validationResult.params, prefix);
+                            errors.push.apply(errors, _toConsumableArray(_validationResult.errors));
+                        }
                     } else if (typeof paramRequirement === 'string' && paramRequirement) {
                         // paramRequirement is a string specifying the name of a required parameter,
                         // So use the default validation function for validation.

--- a/dist/ParameterValidator.js
+++ b/dist/ParameterValidator.js
@@ -102,15 +102,17 @@ var ParameterValidator = function () {
        *								- If an item is an Object, it's assumed that the object's only key is the name of a parameter to be validated
        *								 and its corresponding value is a function that returns true if that parameter's value in paramsProvided is
        *								 valid.
-       * @param    {Object}    [extractedParams] - This method returns an object containing the names and values of the validated parameters extracted.
-       *                                           By default, it creates a new object and assigns the extracted parameters to it, but if you want this
-       *                                           method to add the extracted params to an existing object (such as the class instance that internally
-       *                                           invokes this method), you can supply that object as the extractedParams parameter.
+       * @param    {Object|null} [extractedParams] - This method returns an object containing the names and values of the validated parameters extracted.
+       *                                             By default, it creates a new object and assigns the extracted parameters to it, but if you want this
+       *                                             method to add the extracted params to an existing object (such as the class instance that internally
+       *                                             invokes this method), you can supply that object as the extractedParams parameter.
        *
        * @param    {Object}    [options] - Additional options
        * @param    {string}    [options.addPrefix] - Specifies a prefix that will be added to each param name before it's assigned to the
        *                                             extractedParams object. This is useful, for example, for prefixing property names with an underscore
        *                                             to indicate that they're private properties.
+       * @param    {class}     [options.errorClass] - Specifies a specific `Error` subclass to throw instead of the default `ParameterValidationError
+       *                                              when invalid parameters are detected.
        * @returns  {Object}    extractedParams - The names and values of the validated parameters extracted.
        *
        * @throws   {ParameterValidationError} Indicates that one or more parameter validation rules failed.
@@ -123,13 +125,16 @@ var ParameterValidator = function () {
 
     _createClass(ParameterValidator, [{
         key: 'validate',
-        value: function validate(paramsProvided, paramRequirements) {
-            var extractedParams = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+        value: function validate(paramsProvided, paramRequirements, extractedParams) {
             var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
+
+            extractedParams = this._getExtractedParamsObject(extractedParams);
+            var ValidationErrorSubclass = this._getValidationErrorSubclass(options);
 
             if (!paramsProvided) {
                 // If only I could use the ParameterValidator here...
-                throw new ParameterValidationError('A params object is required.');
+                throw new ValidationErrorSubclass('A params object is required.');
             }
 
             if (!Array.isArray(paramRequirements)) {
@@ -219,7 +224,7 @@ var ParameterValidator = function () {
 
                 errorMessage = errorMessage.slice(0, -1);
 
-                throw new ParameterValidationError(errorMessage);
+                throw new ValidationErrorSubclass(errorMessage);
             }
 
             return extractedParams;
@@ -273,6 +278,58 @@ var ParameterValidator = function () {
             for (var propertyName in propertiesToAdd) {
                 targetObject[prefix + propertyName] = propertiesToAdd[propertyName];
             }
+        }
+
+        /**
+        * Determines the correct object to use for extractedParams based on what the client provided.
+        *
+        * @param   {Object|Function|null|undefined} - extractedParams argument provided to `validate()`
+        * @returns {Object|Function}
+        * @private
+        */
+
+    }, {
+        key: '_getExtractedParamsObject',
+        value: function _getExtractedParamsObject(extractedParams) {
+
+            if ([null, undefined].includes(extractedParams)) {
+                // The client either didn't provide an extractedParams argument or explicitly set
+                // it to null, so just use a new object.
+                return {};
+            }
+
+            if (['object', 'function'].includes(typeof extractedParams === 'undefined' ? 'undefined' : _typeof(extractedParams))) {
+                // The client provided an existing object or function on which we'll set the extracted params.
+                return extractedParams;
+            }
+
+            throw new Error('Invalid value of \'' + extractedParams + '\' was provided for the extractedParams parameter.');
+        }
+
+        /**
+        * Determines whether to use the default ParameterValidationError or a custom
+        * error subclass passed to `validate()`.
+        *
+        * @param   {options} [options] - options that were passed to `validate()`
+        * @param   {class}   [options.errorClass]
+        * @returns {class}
+        * @private
+        */
+
+    }, {
+        key: '_getValidationErrorSubclass',
+        value: function _getValidationErrorSubclass(options) {
+
+            if ((typeof options === 'undefined' ? 'undefined' : _typeof(options)) !== 'object' || options.errorClass === undefined) {
+                return ParameterValidationError;
+            }
+            var errorClass = options.errorClass;
+            // Verify that errorClass is Error or an Error subclass.
+
+            if (errorClass === Error || errorClass.prototype instanceof Error) {
+                return errorClass;
+            }
+            throw new Error('The errorClass provided was of type ' + (typeof errorClass === 'undefined' ? 'undefined' : _typeof(errorClass)) + ' and was not an Error subclass.');
         }
 
         /*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parameter-validator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Parameter validator makes it easy to verify that an object contains required, valid parameters.",
   "keywords": [ "parameter", "validator", "validate", "verify", "assert", "object", "param", "property", "properties", "function", "required" ],
   "repository": "https://github.com/MyPureCloud/parameter-validator",

--- a/src/ParameterValidator.js
+++ b/src/ParameterValidator.js
@@ -95,16 +95,17 @@ export default class ParameterValidator {
                 this._assignProperties(extractedParams, validationResult.params, prefix);
         		errors.push(...validationResult.errors);
 
-        	} else if ((typeof paramRequirement === 'object') && Object.keys(paramRequirement)) {
-				// paramRequirement is an object with one key where the key is the parameter's name
-				// and the value is a validation function that returns true if the value is valid.
-                let paramName = Object.keys(paramRequirement)[0],
-                    validationFunction = paramRequirement[paramName],
-                    validationResult = this._executeValidationFunction(paramsProvided, paramName, validationFunction);
+        	} else if (typeof paramRequirement === 'object') {
+				// paramRequirement is an object with one or more keys where each key is a parameter's name
+				// and its value is a validation function that returns true if the value is valid.
+                for (let paramName in paramRequirement) {
 
-                this._assignProperties(extractedParams, validationResult.params, prefix);
-                errors.push(...validationResult.errors);
+                    let validationFunction = paramRequirement[paramName],
+                        validationResult = this._executeValidationFunction(paramsProvided, paramName, validationFunction);
 
+                    this._assignProperties(extractedParams, validationResult.params, prefix);
+                    errors.push(...validationResult.errors);
+                }
         	} else if ((typeof paramRequirement === 'string') && paramRequirement) {
         		// paramRequirement is a string specifying the name of a required parameter,
         		// So use the default validation function for validation.

--- a/src/ParameterValidator.js
+++ b/src/ParameterValidator.js
@@ -47,15 +47,17 @@ export default class ParameterValidator {
     *								- If an item is an Object, it's assumed that the object's only key is the name of a parameter to be validated
     *								 and its corresponding value is a function that returns true if that parameter's value in paramsProvided is
     *								 valid.
-    * @param    {Object}    [extractedParams] - This method returns an object containing the names and values of the validated parameters extracted.
-    *                                           By default, it creates a new object and assigns the extracted parameters to it, but if you want this
-    *                                           method to add the extracted params to an existing object (such as the class instance that internally
-    *                                           invokes this method), you can supply that object as the extractedParams parameter.
+    * @param    {Object|null} [extractedParams] - This method returns an object containing the names and values of the validated parameters extracted.
+    *                                             By default, it creates a new object and assigns the extracted parameters to it, but if you want this
+    *                                             method to add the extracted params to an existing object (such as the class instance that internally
+    *                                             invokes this method), you can supply that object as the extractedParams parameter.
     *
     * @param    {Object}    [options] - Additional options
     * @param    {string}    [options.addPrefix] - Specifies a prefix that will be added to each param name before it's assigned to the
     *                                             extractedParams object. This is useful, for example, for prefixing property names with an underscore
     *                                             to indicate that they're private properties.
+    * @param    {class}     [options.errorClass] - Specifies a specific `Error` subclass to throw instead of the default `ParameterValidationError
+    *                                              when invalid parameters are detected.
     * @returns  {Object}    extractedParams - The names and values of the validated parameters extracted.
     *
     * @throws   {ParameterValidationError} Indicates that one or more parameter validation rules failed.
@@ -64,10 +66,14 @@ export default class ParameterValidator {
     * let parameterValidator = new ParameterValidator();
 	* parameterValidator.validate(params, ['requiredParam0', 'requiredParam1', ['eitherNeedThis', 'orThat'], {param3: (val) => val > 30}]);
 	*/
-    validate(paramsProvided, paramRequirements, extractedParams = {}, options = {}) {
+    validate(paramsProvided, paramRequirements, extractedParams, options = {}) {
+
+        extractedParams = this._getExtractedParamsObject(extractedParams);
+        const ValidationErrorSubclass = this._getValidationErrorSubclass(options);
+
         if (!paramsProvided) {
         	// If only I could use the ParameterValidator here...
-            throw new ParameterValidationError(`A params object is required.`);
+            throw new ValidationErrorSubclass(`A params object is required.`);
         }
 
         if (!Array.isArray(paramRequirements)) {
@@ -116,7 +122,7 @@ export default class ParameterValidator {
         	}
         	errorMessage = errorMessage.slice(0, -1);
 
-        	throw new ParameterValidationError(errorMessage);
+        	throw new ValidationErrorSubclass(errorMessage);
         }
 
         return extractedParams;
@@ -158,6 +164,51 @@ export default class ParameterValidator {
         for (let propertyName in propertiesToAdd) {
             targetObject[prefix + propertyName] = propertiesToAdd[propertyName];
         }
+    }
+
+    /**
+    * Determines the correct object to use for extractedParams based on what the client provided.
+    *
+    * @param   {Object|Function|null|undefined} - extractedParams argument provided to `validate()`
+    * @returns {Object|Function}
+    * @private
+    */
+    _getExtractedParamsObject(extractedParams) {
+
+        if ([ null, undefined ].includes(extractedParams)) {
+            // The client either didn't provide an extractedParams argument or explicitly set
+            // it to null, so just use a new object.
+            return {};
+        }
+
+        if ([ 'object', 'function' ].includes(typeof extractedParams)) {
+            // The client provided an existing object or function on which we'll set the extracted params.
+            return extractedParams;
+        }
+
+        throw new Error(`Invalid value of '${extractedParams}' was provided for the extractedParams parameter.`);
+    }
+
+    /**
+    * Determines whether to use the default ParameterValidationError or a custom
+    * error subclass passed to `validate()`.
+    *
+    * @param   {options} [options] - options that were passed to `validate()`
+    * @param   {class}   [options.errorClass]
+    * @returns {class}
+    * @private
+    */
+    _getValidationErrorSubclass(options) {
+
+        if ((typeof options !== 'object') || (options.errorClass === undefined)) {
+            return ParameterValidationError;
+        }
+        let { errorClass } = options;
+        // Verify that errorClass is Error or an Error subclass.
+        if (errorClass === Error || errorClass.prototype instanceof Error) {
+            return errorClass;
+        }
+        throw new Error(`The errorClass provided was of type ${typeof errorClass} and was not an Error subclass.`);
     }
 
     /*

--- a/test/ParameterValidator_spec.js
+++ b/test/ParameterValidator_spec.js
@@ -198,27 +198,33 @@ describe('ParameterValidator', () => {
             });
         });
 
-        describe('execution of a custom validation function', () => {
-            it('should return a parameter specified if it passes validation', () => {
+        describe('execution of custom validation functions', () => {
+            it('should return the parameters specified if they passes validation', () => {
                 var animalNames = {
                     cat: 'Garfield',
                     dog: 'Jake',
                     squirrel: 'Rocky'
                 };
 
-                var extractedParams =  parameterValidator.validate(animalNames, [{cat: catNameIsCool}]);
+                var extractedParams =  parameterValidator.validate(animalNames, [{
+                    cat: catNameIsCool,
+                    dog: name => name !== 'Beethoven'
+                }]);
 
-                expect(extractedParams).to.deep.equal({cat: 'Garfield'});
+                expect(extractedParams).to.deep.equal({ cat: 'Garfield', dog: 'Jake' });
             });
 
-            it('should throw a ParameterValidationError if a custom validation function determines a parameter is invalid', () => {
+            it('should throw a ParameterValidationError if a custom validation function determines one parameter is invalid', () => {
                 var animalNames = {
                     cat: 'Sylvester',
                     dog: 'Jake'
                 };
 
                 try {
-                    parameterValidator.validate(animalNames, [{cat: catNameIsCool}]);
+                    parameterValidator.validate(animalNames, [{
+                        cat: catNameIsCool,
+                        dog: name => [ 'Jake', 'Lassie' ].includes(name)
+                    }]);
                     throw new Error('validate() didn\'t throw an error like it was supposed to.');
                 } catch(error) {
                     expect(error).to.be.instanceof(ParameterValidationError);
@@ -226,6 +232,26 @@ describe('ParameterValidator', () => {
                 }
             });
 
+            it('should throw a ParameterValidationError if a custom validation function determines multiple parameters are invalid', () => {
+                var animalNames = {
+                    cat: 'Sylvester',
+                    dog: 'Jake'
+                };
+
+                try {
+                    parameterValidator.validate(animalNames, [{
+                        cat: catNameIsCool,
+                        dog: name => [ 'Clifford', 'Lassie' ].includes(name)
+                    }]);
+                    throw new Error(`validate() didn't throw an error like it was supposed to.`);
+                } catch(error) {
+                    expect(error).to.be.instanceof(ParameterValidationError);
+
+                    let expectedMessage = `ParameterValidationError: Invalid value of 'Sylvester' was provided for parameter 'cat'. ` +
+                                          `Invalid value of 'Jake' was provided for parameter 'dog'.`;
+                    expect(error.toString()).to.equal(expectedMessage);
+                }
+            });
 
             it('should add extracted parameters to an existing object if one is supplied as the extractedParams parameter', () => {
                 var animalNames = {

--- a/test/ParameterValidator_spec.js
+++ b/test/ParameterValidator_spec.js
@@ -247,6 +247,22 @@ describe('ParameterValidator', () => {
                 expect(extractedParams).to.deep.equal(expectedUpdatedExistingParams);
                 expect(existingParams).to.deep.equal(expectedUpdatedExistingParams);
             });
+
+            it('should add extracted parameters to a new object if null is supplied as the extractedParams parameter', () => {
+                var animalNames = {
+                    cat: 'Garfield',
+                    dog: 'Beethoven',
+                    squirrel: 'Rocky'
+                };
+
+                var expectedExtractedParams = cloneDeep(animalNames);
+                delete expectedExtractedParams.squirrel;
+
+                var extractedParams =  parameterValidator.validate(animalNames, [{cat: catNameIsCool}, {dog: dogNameIsCool}], null);
+
+                expect(extractedParams).to.deep.equal(expectedExtractedParams);
+                expect(extractedParams).to.deep.equal(expectedExtractedParams);
+            });
         });
 
         describe('combining different types of validation', () => {
@@ -341,6 +357,32 @@ describe('ParameterValidator', () => {
                     _penguin: 'Tux',
                     _bear: 'Yogi'
                 });
+            });
+        });
+
+        describe('errorClass option', () => {
+
+            it('allows a different Error subclass to be used instead of ParameterValidationError', () => {
+
+                class CustomValidationError extends Error {
+                    constructor(message) {
+                        super(message);
+                        this.name = this.constructor.name;
+                        this.message = message;
+                        if (Error.captureStackTrace) {
+                            Error.captureStackTrace(this, this.constructor.name);
+                        }
+                    }
+                }
+                let lilBub = { type: 'cat' };
+
+                try {
+                    parameterValidator.validate(lilBub, [ 'type', 'interests' ], null, { errorClass: CustomValidationError });
+                    expect(`failing the test because an error wasn't thrown`).to.equal(true);
+                } catch (error) {
+                    expect(error).to.be.instanceof(CustomValidationError);
+                    expect(error.message).to.include('interests');
+                }
             });
         });
     });


### PR DESCRIPTION
This PR contains a few updates that I've been wanting:

1. You can now provide a custom Error class that will be thrown instead of `ParameterValidationError`. One place this comes in handy is for validating HTTP request bodies.

```
validate(req.body, [ 'firstName' ], this, { errorClass: BadRequestError });
```

2. Previously, if you wanted to provide custom validation functions for multiple params, you'd have to pass multiple objects like so:

```
validate(req.body, [ { age: Number.isInteger }, { quantity: Number.isInteger } ]);
```

Now you can pass these in a single object:
```
validate(req.body, [ { age: Number.isInteger, quantity: Number.isInteger } ]);
```

3. Made it so that you can pass `null` as the 3rd parameter in case you want to specify options in the 4th parameter but don't want to supply an object to which extracted parameters will be applied:

```
validate(req.body, [ 'firstName' ], null, { errorClass: BadRequestError });
```